### PR TITLE
[VHDL] Fix VHDL implementation of bitwidth modifiers

### DIFF
--- a/components/arithmetic_units.vhd
+++ b/components/arithmetic_units.vhd
@@ -279,7 +279,7 @@ begin
 
     dataOutArray(0)<= std_logic_vector(IEEE.numeric_std.resize(signed(dataInArray(0)),DATA_SIZE_OUT));
     validArray <= pValidArray;
-    readyArray(0) <= not pValidArray(0) or (pValidArray(0) and nReadyArray(0));
+    readyArray(0) <= nReadyArray(0);
 
 end architecture;
 
@@ -314,7 +314,7 @@ begin
 
     dataOutArray(0)<= std_logic_vector(IEEE.numeric_std.resize(signed(dataInArray(0)),DATA_SIZE_OUT));
     validArray <= pValidArray;
-    readyArray(0) <= not pValidArray(0) or (pValidArray(0) and nReadyArray(0));
+    readyArray(0) <= nReadyArray(0);
 
 end architecture;
 -----------------------------------------------------------------------
@@ -3294,7 +3294,7 @@ begin
     
     dataOutArray(0)<= dataInArray(0)(DATA_SIZE_OUT - 1 downto 0);
     validArray <= pValidArray;
-    readyArray(0) <= not pValidArray(0) or (pValidArray(0) and nReadyArray(0));
+    readyArray(0) <= nReadyArray(0);
 
 end architecture;
 


### PR DESCRIPTION
This commit replaces the Handshaking logic in the VHDL implementation of the bitwidth modifier entities `trunc_op`, `sext_op`, and `zext_op`. Previously, the ready signal was computed as a combination of the `pValidArray` (valid predecessor signal) and the `nReadyArray` (ready successor signal). While this works in most cases, it is too conservative and may cause deadlocks/critical path increases. As such, the ready signal is modified to just "forward" the dataflow successor's one. This makes the bitwidth modification components act as perfect "forwarders" of control signals, only altering the data signal in the process. 